### PR TITLE
Allow injections into other grammars

### DIFF
--- a/grammars/mathematica.cson
+++ b/grammars/mathematica.cson
@@ -1,5 +1,6 @@
 'scopeName': 'source.mathematica'
 'name': 'Mathematica'
+'injectionSelector': 'source.embedded.mathematica'
 'fileTypes': [
   'm'
   'wl'


### PR DESCRIPTION
The added property tells Atom which scopes to apply this grammar's rules to, when the base language is not this one. 

For example, `language-hyperlink` uses `'text - string.regexp, string - string.regexp, comment, source.gfm'` (the `-` sign means the following scope is not allowed; so it injects in `text`, but not when also in `string.regexp`).

This is a fix on this end for https://github.com/atom/language-gfm/issues/213, where a user has requested embedded mathematica support. Implementing this means that `language-gfm` will be able to embed this grammar correctly without any changes on their end.