### PR TITLE
Add file extension support for WL testing files

### DIFF
--- a/grammars/mathematica.cson
+++ b/grammars/mathematica.cson
@@ -4,6 +4,8 @@
   'm'
   'wl'
   'wls'
+  'mt'
+  'wlt'
 ]
 'patterns': [
   {


### PR DESCRIPTION
These are lesser used, but discussed in various places online:
https://mathematica.stackexchange.com/questions/170947/best-practices-for-using-the-testing-framework

I don't think these extensions are common enough to interfere elsewhere.